### PR TITLE
Oauth 2.0 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ target/
 *.iws
 *.iml
 *.ipr
+*.yml
 
 ### NetBeans ###
 /nbproject/private/

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,13 @@
             <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
 
+        <!-- oauth2.0 -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+            <version>2.3.0.RELEASE</version>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/java/com/simple/portal/biz/v1/user/api/OAuth2Controller.java
+++ b/src/main/java/com/simple/portal/biz/v1/user/api/OAuth2Controller.java
@@ -1,0 +1,27 @@
+package com.simple.portal.biz.v1.user.api;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class OAuth2Controller {
+    @GetMapping("/")
+    public String home( ) {
+        return "home";
+    }
+
+    @GetMapping("/login")
+    public String login( ) {
+        return "login";
+    }
+
+    @GetMapping({"/loginSuccess", "/hello"})
+    public String loginSuccess( ) {
+        return "hello";
+    }
+
+    @GetMapping("/loginFailure")
+    public String loginFailure( ) {
+        return "loginFailure";
+    }
+}

--- a/src/main/java/com/simple/portal/biz/v1/user/api/UserAPI.java
+++ b/src/main/java/com/simple/portal/biz/v1/user/api/UserAPI.java
@@ -14,6 +14,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.view.RedirectView;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -35,7 +36,6 @@ public class UserAPI {
         this.userService = userService;
         this.apiResponse = apiResponse;
     }
-
 /*
     @GetMapping("/jsaypt")
     public void jsapt( ) {
@@ -163,16 +163,18 @@ public class UserAPI {
 
     // 권한 업데이트
     @GetMapping("/auth")
-    public ModelAndView auth_update(@RequestParam(value="userId") @NotNull String userId) {
+    public RedirectView auth_update(@RequestParam(value="userId") @NotNull String userId) {
 
         log.info("[GET] /user/auth/ " + userId);
         Boolean res = userService.updateUserAuthService(userId);
+        RedirectView redirectView = new RedirectView();
 
         if(res) { // 권한 업데이트 성공
-           return new ModelAndView("/mail-redirect-success-page");
+            redirectView.setUrl("http://www.naver.com"); // 인증 성공했을때 페이지
         } else { // 권한 업데이트 실패
-            return new ModelAndView("/mail-redirect-fail-page");
+            redirectView.setUrl("http://www.naver.com"); // 인증 실패했을때 페이지
         }
+        return redirectView;
     }
 
     // 비밀번호 변경

--- a/src/main/java/com/simple/portal/biz/v1/user/dto/OAuthAttributes.java
+++ b/src/main/java/com/simple/portal/biz/v1/user/dto/OAuthAttributes.java
@@ -1,0 +1,96 @@
+package com.simple.portal.biz.v1.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Getter
+public class OAuthAttributes {
+    private Map<String, Object> attributes;
+    private String nameAttributeKey;
+    private String name;
+    private String email;
+    private String picture;
+
+    @Builder
+    public OAuthAttributes(Map<String, Object> attributes,
+                           String nameAttributeKey, String name,
+                           String email, String picture) {
+        this.attributes = attributes;
+        this.nameAttributeKey= nameAttributeKey;
+        this.name = name;
+        this.email = email;
+        this.picture = picture;
+    }
+
+    public static OAuthAttributes of(String registrationId,
+                                     String userNameAttributeName,
+                                     Map<String, Object> attributes) {
+
+        if("naver".equals(registrationId)) return ofNaver(attributes);
+        else if("github".equals(registrationId)) return ofGithub(userNameAttributeName, attributes);
+        else if ("facebook".equals(registrationId))  return ofFaceBook(userNameAttributeName, attributes);
+        return ofGoogle(userNameAttributeName, attributes); // 구글
+    }
+
+    // 구글
+    private static OAuthAttributes ofGoogle(String userNameAttributeName,
+                                            Map<String, Object> attributes) {
+
+
+        return OAuthAttributes.builder()
+                .name((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .picture((String) attributes.get("picture"))
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    // 페이스북  -> 이미지 파싱 필요
+    private static OAuthAttributes ofFaceBook(String userNameAttributeName,
+                                              Map<String, Object> attributes) {
+
+        //  picture={data={height=50, is_silhouette=false, url=https://platform-lookaside.fbsbx.com/platform/profilepic/?asid=3051485381636996&height=50&width=50&ext=1600003018&hash=AeRTziYd2gCIfv4X, width=50}}}
+        //  picture, data가 linkedHashMap으로 구현되어있음....
+
+        LinkedHashMap<String, Object> facebookPicture = (LinkedHashMap<String, Object>) attributes.get("picture");
+        LinkedHashMap<String, Object> facebookPictureData = (LinkedHashMap<String, Object>) facebookPicture.get("data");
+
+        return OAuthAttributes.builder()
+                .name((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .picture(facebookPictureData.get("url").toString())
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    // 깃허브 -> login : 닉네임, avatar_url : 프로필 이미지, email: 이메일 정보
+    private static OAuthAttributes ofGithub(String userNameAttributeName,
+                                            Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .name((String) attributes.get("bio"))
+                .email((String) attributes.get("email"))
+                .picture((String) attributes.get("avatar_url"))
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    //네이버
+    private static OAuthAttributes ofNaver(Map<String, Object> attributes) {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        return OAuthAttributes.builder()
+                .name((String) response.get("name"))
+                .email((String) response.get("email"))
+                .picture((String) response.get("profile_image"))
+                .attributes(response)
+                .nameAttributeKey("id")
+                .build();
+    }
+
+}

--- a/src/main/java/com/simple/portal/biz/v1/user/security/SocialType.java
+++ b/src/main/java/com/simple/portal/biz/v1/user/security/SocialType.java
@@ -1,0 +1,23 @@
+package com.simple.portal.biz.v1.user.security;
+
+public enum SocialType {
+    FACEBOOK("facebook"),
+    GOOGLE("google"),
+    NAVER("naver"),
+    GITHUB("github");
+
+    private final String Role_Prefix = "ROLE_";
+    private String name;
+
+    SocialType(String name) { this.name = name;}
+
+    public String getRoleType( ) {
+        return Role_Prefix + name.toUpperCase();
+    }
+
+    public String getValue() {return name;}
+
+    public boolean isEqual(String authority) {
+        return this.getRoleType().equals(authority);
+    }
+}

--- a/src/main/java/com/simple/portal/biz/v1/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/simple/portal/biz/v1/user/service/CustomOAuth2UserService.java
@@ -1,0 +1,51 @@
+package com.simple.portal.biz.v1.user.service;
+
+import com.simple.portal.biz.v1.user.dto.OAuthAttributes;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Slf4j
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();;
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        OAuthAttributes attributes = OAuthAttributes.
+                of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+
+        log.info("nickname : " + attributes.getName());
+        log.info("email : " +  attributes.getEmail());
+        log.info("profile : " + attributes.getPicture());
+        log.info("full data : " + attributes.getAttributes());
+
+        Set<GrantedAuthority> authorities = new LinkedHashSet<>();
+        authorities.add(new OAuth2UserAuthority(attributes.getAttributes()));
+        OAuth2AccessToken token = userRequest.getAccessToken();
+        for (String authority : token.getScopes()) {
+            authorities.add(new SimpleGrantedAuthority("SCOPE_" + authority));
+        }
+
+        return new DefaultOAuth2User(
+                authorities,
+                attributes.getAttributes(),
+                attributes.getNameAttributeKey());
+    }
+}

--- a/src/main/java/com/simple/portal/config/SecurityConfig.java
+++ b/src/main/java/com/simple/portal/config/SecurityConfig.java
@@ -1,14 +1,20 @@
 package com.simple.portal.config;
 
+import com.simple.portal.biz.v1.user.service.CustomOAuth2UserService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+
+import static com.simple.portal.biz.v1.user.security.SocialType.*;
 
 @Configuration
+@EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     /**
@@ -31,18 +37,27 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http.cors().and()
             .csrf()
             .disable()// rest api이므로 csrf 보안이 필요없으므로 disable처리.
-            .authorizeRequests()
+            .authorizeRequests().antMatchers("/", "/oauth2/**", "/login/**", "/css/**", "/images/**", "/js/**", "/console/**", "/favicon.ico/**") // // url 별 권한 관리를 설정하는 옵션의 시작점. 이게 선언되어야 antMatchers  옵션을 사용할 수 있음.
+                .permitAll()  // 위에 있는 경로는 누구나 접근 가능
+                .antMatchers("/google").hasAuthority(GOOGLE.getRoleType()) // 관리 대상을 지정하는 옵션. google, facebook, naver는 role을 가지고 있어야만 접근가능. 즉, 인증된 사용자만 가능
+                .antMatchers("/facebook").hasAuthority(FACEBOOK.getRoleType())
+                .antMatchers("/naver").hasAuthority(NAVER.getRoleType())
+                .antMatchers("/github").hasAnyAuthority(GITHUB.getRoleType())
             .antMatchers("/v1/api/**", "/h2-console/**").permitAll()
             .antMatchers("/user").hasAuthority("USER")
             .antMatchers("/admin").hasAuthority("ADMIN")
-            .anyRequest().authenticated()
-            .and()
-    //               .formLogin()
-    //                    .and()
-            .logout()
-        ;
-        http.headers().frameOptions().disable();
-
+            .anyRequest().authenticated()// anyRequest( )는 위에서 설정한 것 외의 나머지 경로를 뜻함. authenticated() 메소드를 호출하여 인증된 사용자만 접근 하도록 함. ( 로그인된 사용자 )
+            .and().oauth2Login()
+                .userInfoEndpoint().userService(new CustomOAuth2UserService())
+                .and()
+                .defaultSuccessUrl("/loginSuccess")// 성공시 redirect 될 url
+                .failureUrl("/loginFailure")// 실패시 redirect 될 url
+                .and()
+                .exceptionHandling()
+                .authenticationEntryPoint(new LoginUrlAuthenticationEntryPoint("/login"));
+        //
+        //       .logout();
+        //  http.headers().frameOptions().disable();
     }
 
     @Override
@@ -53,9 +68,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 "/websocket", "/sockjs", "/websockethandler/**", "/webjars/**", "/greetings/**");
     }
 
+    /*
     @Bean
     @Override
     public AuthenticationManager authenticationManagerBean() throws Exception {
         return super.authenticationManagerBean();
     }
+    */
 }

--- a/src/main/resources/templates/hello.html
+++ b/src/main/resources/templates/hello.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title></head>
+<body><h1>인증을 무사히 완료하였습니다.</h1></body>
+</html>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title></head>
+<body><h1>홈페이지입니다.</h1><br> <a th:href="@{/login}">로그인 하기</a></body>
+</html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title></head>
+    <body>
+       <h2>로그인</h2><br/><br/>
+
+       <a href="javascript:;" class="btn_social" data-social="facebook">페이스북 로그인</a><br/>
+       <a href="javascript:;" class="btn_social" data-social="google">구글 로그인</a><br/>
+       <a href="javascript:;" class="btn_social"  data-social="github">깃허브 로그인</a><br/>
+       <a href="javascript:;" class="btn_social" data-social="naver">네이버 로그인</a><br/>
+
+<script>
+    let socials = document.getElementsByClassName("btn_social");
+    for (let social of socials) {
+        social.addEventListener('click', function () {
+        let socialType = this.getAttribute('data-social');
+        location.href = "/oauth2/authorization/" + socialType;
+    })
+} </script>
+</body>
+</html>

--- a/src/main/resources/templates/loginFaillure.html
+++ b/src/main/resources/templates/loginFaillure.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title></head>
+<body><h1>인증을 실패하였습니다.</h1> <a th:href="@{/login}">다시 로그인하기</a></body>
+</html>


### PR DESCRIPTION
[ pr 내용 ]
1. oauth 2.0 기능 추가 ( google, facebook, naver, github )
2. yml에 client-secret은 노출되면 안될거 같아서 일단 yml을 .gitignore에 추가했습니다.. ( 어떻게 할지는 추후 논의가 필요할거 같습니다.)

추가적으로, SecurityConfig에 authenticationManagerBean 이 bean에서 뭔가 충돌나는거 같아서 일단 주석처리하고 로컬에서 Oauth 동작 확인했는데 authenticationManagerBean 해당 bean이 어디에 쓰이는건지 알 수 있을까요??